### PR TITLE
Update header to 2.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v2.2.13
+- Updating @nypl/dgx-header-component to 2.5.8
+
 ### v2.2.12
 - Updating @nypl/dgx-header-component to 2.5.6
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Web App that renders the NYPL Booklists discoverable at https://nypl.org/b
 * /books-music-dvds/recommendations/lists/asknypl
 
 ## Version
-> v2.2.12
+> v2.2.13
 
 ## Node Configuration
 Pass in the following environment variables:  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-booklists",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "NYPL Isomorphic React Booklists with Webpack",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "eslint-plugin-react": "5.2.2"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "2.5.6",
+    "@nypl/dgx-header-component": "2.5.8",
     "@nypl/dgx-react-footer": "0.5.2",
     "assets-webpack-plugin": "3.4.0",
     "axios": "0.9.1",


### PR DESCRIPTION
Update header to 2.5.8 to incorporate [login/logout fixes](https://github.com/NYPL/dgx-header-component/pull/79).