### PR TITLE
RENO-1153-update-dgx-react-footer-to-0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v2.2.15
+- Updating @nypl/dgx-react-footer to 0.5.4.
+
 ### v2.2.14
 - Updating @nypl/dgx-header-component to 2.6.0
 
@@ -17,7 +20,6 @@
 
 ### v2.2.9
 - Updating @nypl/dgx-react-footer to 0.5.2.
-
 
 ### v2.2.8
 - Updating @nypl/dgx-header-component to 2.4.19.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Web App that renders the NYPL Booklists discoverable at https://nypl.org/b
 * /books-music-dvds/recommendations/lists/asknypl
 
 ## Version
-> v2.2.14
+> v2.2.15
 
 ## Node Configuration
 Pass in the following environment variables:  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-booklists",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "description": "NYPL Isomorphic React Booklists with Webpack",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "assets-webpack-plugin": "3.4.0",
     "axios": "0.9.1",
     "babel-core": "6.5.2",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)