### PR TITLE
RENO-1275: update dgx-react-footer to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v2.2.17
+- Updating @nypl/dgx-react-footer to 0.5.6.
+
 ### v2.2.16
 - Updating @nypl/dgx-react-footer to 0.5.5.
 - Updating Falcon Crowdstike sensor to 5.29.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Web App that renders the NYPL Booklists discoverable at https://nypl.org/b
 * /books-music-dvds/recommendations/lists/asknypl
 
 ## Version
-> v2.2.16
+> v2.2.17
 
 ## Node Configuration
 Pass in the following environment variables:  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-booklists",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "NYPL Isomorphic React Booklists with Webpack",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.5",
+    "@nypl/dgx-react-footer": "0.5.6",
     "assets-webpack-plugin": "3.4.0",
     "axios": "0.9.1",
     "babel-core": "6.5.2",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1275)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.6

**Note**: I was unable to run this app locally. The browser window was blank with some JS errors. This was the same before this update was applied.