### PR TITLE
RENO-1829: Update dgx-header-component to v.2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v2.2.18
+- Updating @nypl/dgx-header-component to 2.7.1.
+
 ### v2.2.17
 - Updating @nypl/dgx-react-footer to 0.5.6.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Web App that renders the NYPL Booklists discoverable at https://nypl.org/b
 * /books-music-dvds/recommendations/lists/asknypl
 
 ## Version
-> v2.2.17
+> v2.2.18
 
 ## Node Configuration
 Pass in the following environment variables:  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-booklists",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "NYPL Isomorphic React Booklists with Webpack",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "eslint-plugin-react": "5.2.2"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "2.6.0",
+    "@nypl/dgx-header-component": "2.7.1",
     "@nypl/dgx-react-footer": "0.5.6",
     "assets-webpack-plugin": "3.4.0",
     "axios": "0.9.1",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1829)

**This PR does the following:**

- Updates dgx-header-component to v2.7.1

This update adds the text centering to the global messaging.